### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI & Lint
 
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/x7finance/telegram-bot/security/code-scanning/2](https://github.com/x7finance/telegram-bot/security/code-scanning/2)

The problem is best fixed by adding a `permissions` block to either the entire workflow (top-level, applying to all jobs) or specifically to the `test` job. The minimal and recommended change is to add a `permissions` block at the top level (i.e., right under the `name` or `on` keyword), specifying `contents: read`. This ensures that the automatically generated `GITHUB_TOKEN` will only have read access to repository contents during workflow execution, adhering to the principle of least privilege. Only lines near the top of `.github/workflows/ci.yml` are changed; no existing functionality will be impacted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
